### PR TITLE
Upgrade to v3 of the jwt-go dependacy

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -29,6 +29,7 @@ func (h JWTAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 		if err != nil {
 			return http.StatusUnauthorized, nil
 		}
+		vClaims := vToken.Claims.(jwt.MapClaims)
 
 		// If token contains rules with allow or deny, evaluate
 		if len(p.AccessRules) > 0 {
@@ -36,17 +37,17 @@ func (h JWTAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 			for _, rule := range p.AccessRules {
 				switch rule.Authorize {
 				case ALLOW:
-					if vToken.Claims[rule.Claim] == rule.Value {
+					if vClaims[rule.Claim] == rule.Value {
 						isAuthorized = append(isAuthorized, true)
 					}
-					if vToken.Claims[rule.Claim] != rule.Value {
+					if vClaims[rule.Claim] != rule.Value {
 						isAuthorized = append(isAuthorized, false)
 					}
 				case DENY:
-					if vToken.Claims[rule.Claim] == rule.Value {
+					if vClaims[rule.Claim] == rule.Value {
 						isAuthorized = append(isAuthorized, false)
 					}
-					if vToken.Claims[rule.Claim] != rule.Value {
+					if vClaims[rule.Claim] != rule.Value {
 						isAuthorized = append(isAuthorized, true)
 					}
 				default:
@@ -66,7 +67,7 @@ func (h JWTAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 		}
 
 		// set claims as separate headers for downstream to consume
-		for claim, value := range vToken.Claims {
+		for claim, value := range vClaims {
 			c := strings.ToUpper(claim)
 			switch value.(type) {
 			case string:

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -33,10 +33,10 @@ func passThruHandler(w http.ResponseWriter, r *http.Request) (int, error) {
 
 func genToken(secret string, claims map[string]string) string {
 	token := jwt.New(jwt.SigningMethodHS256)
-	token.Claims["exp"] = time.Now().Add(time.Hour * 1).Unix()
+	token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 1).Unix()
 
 	for claim, value := range claims {
-		token.Claims[claim] = value
+		token.Claims.(jwt.MapClaims)[claim] = value
 	}
 	validToken, err := token.SignedString([]byte(secret))
 	if err != nil {
@@ -102,7 +102,7 @@ var _ = Describe("JWTAuth", func() {
 				Fail("unexpected error setting JWT_SECRET")
 			}
 			token := jwt.New(jwt.SigningMethodHS256)
-			token.Claims["exp"] = time.Now().Add(time.Hour * 1).Unix()
+			token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 1).Unix()
 			sToken, err := token.SignedString([]byte("secret"))
 			if err != nil {
 				Fail(fmt.Sprintf("unexpected error constructing token: %s", err))
@@ -119,7 +119,7 @@ var _ = Describe("JWTAuth", func() {
 				Fail("unexpected error setting JWT_SECRET")
 			}
 			token := jwt.New(jwt.SigningMethodHS256)
-			token.Claims["exp"] = time.Now().Add(time.Hour * 1).Unix()
+			token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 1).Unix()
 			sToken, err := token.SignedString([]byte("notsecret"))
 			if err != nil {
 				Fail(fmt.Sprintf("unexpected error constructing token: %s", err))
@@ -136,7 +136,7 @@ var _ = Describe("JWTAuth", func() {
 				Fail("unexpected error setting JWT_SECRET")
 			}
 			token := jwt.New(jwt.SigningMethodHS256)
-			token.Claims["exp"] = time.Now().Add(time.Hour * -1).Unix()
+			token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * -1).Unix()
 			sToken, err := token.SignedString([]byte("secret"))
 			if err != nil {
 				Fail(fmt.Sprintf("unexpected error constructing token: %s", err))
@@ -154,7 +154,7 @@ var _ = Describe("JWTAuth", func() {
 			}
 			token := jwt.New(jwt.SigningMethodHS256)
 			token.Header["alg"] = "none"
-			token.Claims["exp"] = time.Now().Add(time.Hour * 1).Unix()
+			token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 1).Unix()
 			sToken, err := token.SignedString([]byte("secret"))
 			if err != nil {
 				Fail(fmt.Sprintf("unexpected error constructing token: %s", err))
@@ -177,12 +177,12 @@ var _ = Describe("JWTAuth", func() {
 			Fail("unexpected error setting JWT_SECRET")
 		}
 		token := jwt.New(jwt.SigningMethodHS256)
-		token.Claims["exp"] = time.Now().Add(time.Hour * 1).Unix()
-		token.Claims["user"] = "test"
-		token.Claims["int32"] = int32(10)
-		token.Claims["float32"] = float32(3.14159)
-		token.Claims["float64"] = float64(3.14159)
-		token.Claims["bool"] = true
+		token.Claims.(jwt.MapClaims)["exp"] = time.Now().Add(time.Hour * 1).Unix()
+		token.Claims.(jwt.MapClaims)["user"] = "test"
+		token.Claims.(jwt.MapClaims)["int32"] = int32(10)
+		token.Claims.(jwt.MapClaims)["float32"] = float32(3.14159)
+		token.Claims.(jwt.MapClaims)["float64"] = float64(3.14159)
+		token.Claims.(jwt.MapClaims)["bool"] = true
 
 		validToken, err := token.SignedString([]byte("secret"))
 		if err != nil {


### PR DESCRIPTION
- Add jwt.MapClaims type assertion to fix missing indexing support for
  type jwt.Claims

Followed migration guide at:
https://github.com/dgrijalva/jwt-go/blob/master/MIGRATION_GUIDE.md