### PR TITLE
fixed possible panic if token is malformed

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -136,12 +136,13 @@ func ValidateToken(uToken string) (*jwt.Token, error) {
 		return secret, nil
 	})
 
-	if token.Valid && err == nil {
-		return token, nil
+	// if token is malformed or invalid, err can be inspected to get more information
+	// about which validation part failed
+	if err != nil {
+		return nil, err
 	}
-	// if token not valid, err can be inspected to get more information about which
-	// part failed validation
-	return nil, err
+
+	return token, nil
 }
 
 // JWT signing token must be set as environment variable JWT_SECRET and not

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	validToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
+	malformedToken = "loremIpsum"
 )
 
 func TestCaddyJwt(t *testing.T) {
@@ -127,6 +128,14 @@ var _ = Describe("JWTAuth", func() {
 			}
 
 			vToken, err := ValidateToken(sToken)
+
+			Expect(err).To(HaveOccurred())
+			Expect(vToken).To(BeNil())
+		})
+
+		It("should not validate a malformed token", func() {
+
+			vToken, err := ValidateToken(malformedToken)
 
 			Expect(err).To(HaveOccurred())
 			Expect(vToken).To(BeNil())


### PR DESCRIPTION
A panic occurs due to the Valid() method call on a non initialized token object if the token signature is malformed.