### PR TITLE
[WIP] RSA support and flatten claim map

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jwt [path1]
 jwt [path2]
 ```
 
-> **Important** You must set the secret used to construct your token in an environment variable named `JWT_SECRET`.  Otherwise, your tokens will always silently fail validation.  Caddy will start without this value set, but it must be present at the time of the request for the signature to be validated.
+> **Important** You must set the secret used to construct your token in an environment variable named `JWT_SECRET`(HMAC) *or* `JWT_PUBLIC_KEY`(RSA).  Otherwise, your tokens will always silently fail validation.  Caddy will start without this value set, but it must be present at the time of the request for the signature to be validated.
 
 ### Advanced Syntax
 
@@ -67,10 +67,9 @@ JWTs consist of three parts: header, claims, and signature.  To properly constru
 ```json
 {
 "typ": "JWT",
-"alg": "HS256|HS384|HS512"
+"alg": "HS256|HS384|HS512|RS256|RS384|RS512"
 }
 ```
-See progress on https://github.com/BTBurke/caddy-jwt/issues/3 if you're interested in public key signing algorithms.
 
 ##### Claims
 If you want to limit the validity of your tokens to a certain time period, use the "exp" field to declare the expiry time of your token.  This time should be a Unix timestamp in integer format.

--- a/flatten.go
+++ b/flatten.go
@@ -1,0 +1,104 @@
+// Flatten makes flat, one-dimensional maps from arbitrarily nested ones.
+//
+// Map keys turn into compound
+// names, like `a.b.1.c` (dotted style) or `a[b][1][c]` (Rails style).  It takes input as either JSON strings or
+// Go structures.  It (only) knows how to traverse JSON types: maps, slices and scalars.
+//
+// Or Go maps directly.
+//
+//	t := map[string]interface{}{
+//		"a": "b",
+//		"c": map[string]interface{}{
+//			"d": "e",
+//			"f": "g",
+//		},
+//		"z": 1.4567,
+//	}
+//
+//	flat, err := Flatten(nested, "", RailsStyle)
+//
+//	// output:
+//	// map[string]interface{}{
+//	//	"a":    "b",
+//	//	"c[d]": "e",
+//	//	"c[f]": "g",
+//	//	"z":    1.4567,
+//	// }
+//
+package jwt
+
+import "errors"
+
+// The presentation style of keys.
+type SeparatorStyle int
+
+const (
+	_ SeparatorStyle = iota
+
+	// Separate nested key components with dots, e.g. "a.b.1.c.d"
+	DotStyle
+
+	// Separate ala Rails, e.g. "a[b][c][1][d]"
+	RailsStyle
+)
+
+// Nested input must be a map or slice
+var NotValidInputError = errors.New("Not a valid input: map or slice")
+
+// Flatten generates a flat map from a nested one.  The original may include values of type map, slice and scalar,
+// but not struct.  Keys in the flat map will be a compound of descending map keys and slice iterations.
+// The presentation of keys is set by style.  A prefix is joined to each key.
+func Flatten(nested map[string]interface{}, prefix string, style SeparatorStyle) (map[string]interface{}, error) {
+	flatmap := make(map[string]interface{})
+
+	err := flatten(true, flatmap, nested, prefix, style)
+	if err != nil {
+		return nil, err
+	}
+
+	return flatmap, nil
+}
+
+func flatten(top bool, flatMap map[string]interface{}, nested interface{}, prefix string, style SeparatorStyle) error {
+	assign := func(newKey string, v interface{}) error {
+		switch v.(type) {
+		case map[string]interface{}:
+			if err := flatten(false, flatMap, v, newKey, style); err != nil {
+				return err
+			}
+		default:
+			flatMap[newKey] = v
+		}
+
+		return nil
+	}
+
+	switch nested.(type) {
+	case map[string]interface{}:
+		for k, v := range nested.(map[string]interface{}) {
+			newKey := enkey(top, prefix, k, style)
+			assign(newKey, v)
+		}
+	default:
+		return NotValidInputError
+	}
+
+	return nil
+}
+
+func enkey(top bool, prefix, subkey string, style SeparatorStyle) string {
+	key := prefix
+
+	if top {
+		key += subkey
+	} else {
+		switch style {
+		case DotStyle:
+			key += "." + subkey
+		case RailsStyle:
+			key += "[" + subkey + "]"
+		}
+	}
+
+	return key
+}

--- a/jwt.go
+++ b/jwt.go
@@ -156,7 +156,7 @@ func ValidateToken(uToken string) (*jwt.Token, error) {
 	if authBackend.HMACSecret != nil {
 		token, err := jwt.Parse(uToken, func(t *jwt.Token) (interface{}, error) {
 			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-				return nil, fmt.Errorf("Unexpected signing method: %v", t.Header["alg"])
+				return nil, fmt.Errorf("HMAC: Unexpected signing method: %v", t.Header["alg"])
 			}
 			return authBackend.HMACSecret, nil
 		})
@@ -170,7 +170,7 @@ func ValidateToken(uToken string) (*jwt.Token, error) {
 	if authBackend.RSAPublicKey != nil {
 		token, err := jwt.Parse(uToken, func(t *jwt.Token) (interface{}, error) {
 			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
-				return nil, fmt.Errorf("Unexpected signing method: %v", t.Header["alg"])
+				return nil, fmt.Errorf("RSA: Unexpected signing method: %v", t.Header["alg"])
 			}
 			return authBackend.RSAPublicKey, nil
 		})

--- a/jwt.go
+++ b/jwt.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"crypto/rsa"
 	"fmt"
 	"net/http"
 	"os"
@@ -8,9 +9,18 @@ import (
 	"strings"
 
 	"bytes"
+
 	"github.com/dgrijalva/jwt-go"
+	"github.com/jeremywohl/flatten"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
+
+type JWTAuthBackend struct {
+	HMACSecret   []byte
+	RSAPublicKey *rsa.PublicKey
+}
+
+var authBackendInstance *JWTAuthBackend = nil
 
 func (h JWTAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 	// if the request path is any of the configured paths, validate JWT
@@ -30,7 +40,10 @@ func (h JWTAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 		if err != nil {
 			return handleUnauthorized(w, r, p), nil
 		}
-		vClaims := vToken.Claims.(jwt.MapClaims)
+		vClaims, err := flatten.Flatten(vToken.Claims.(jwt.MapClaims), "", flatten.DotStyle)
+		if err != nil {
+			return handleUnauthorized(w, r, p), nil
+		}
 
 		// If token contains rules with allow or deny, evaluate
 		if len(p.AccessRules) > 0 {
@@ -119,6 +132,16 @@ func ExtractToken(r *http.Request) (string, error) {
 	return "", fmt.Errorf("no token found")
 }
 
+func InitJWTAuthBackend() *JWTAuthBackend {
+	if authBackendInstance == nil {
+		authBackendInstance = &JWTAuthBackend{
+			HMACSecret:   lookupSecret(),
+			RSAPublicKey: getPublicKey(),
+		}
+	}
+	return authBackendInstance
+}
+
 // ValidateToken will return a parsed token if it passes validation, or an
 // error if any part of the token fails validation.  Possible errors include
 // malformed tokens, unknown/unspecified signing algorithms, missing secret key,
@@ -129,34 +152,63 @@ func ValidateToken(uToken string) (*jwt.Token, error) {
 		return nil, fmt.Errorf("Token length is zero")
 	}
 
-	token, err := jwt.Parse(uToken, func(t *jwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("Unexpected signing method: %v", t.Header["alg"])
-		}
-		secret, err := lookupSecret()
+	authBackend := InitJWTAuthBackend()
+
+	if authBackend.HMACSecret != nil {
+		token, err := jwt.Parse(uToken, func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
+				return nil, fmt.Errorf("Unexpected signing method: %v", t.Header["alg"])
+			}
+			return authBackend.HMACSecret, nil
+		})
+
 		if err != nil {
 			return nil, err
 		}
-		return secret, nil
-	})
 
-	// if token is malformed or invalid, err can be inspected to get more information
-	// about which validation part failed
-	if err != nil {
-		return nil, err
+		return token, nil
 	}
+	if authBackend.RSAPublicKey != nil {
+		token, err := jwt.Parse(uToken, func(t *jwt.Token) (interface{}, error) {
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("Unexpected signing method: %v", t.Header["alg"])
+			}
+			return authBackend.RSAPublicKey, nil
+		})
 
-	return token, nil
+		// if token is malformed or invalid, err can be inspected to get more information
+		// about which validation part failed
+		if err != nil {
+			return nil, err
+		}
+
+		return token, nil
+	}
+	// if token not valid, err can be inspected to get more information about which
+	// part failed validation
+	return nil, fmt.Errorf("JWT_SECRET nor JWT_PUBLIC_KEY is set")
 }
 
 // JWT signing token must be set as environment variable JWT_SECRET and not
 // be the empty string
-func lookupSecret() ([]byte, error) {
+func lookupSecret() []byte {
 	secret := os.Getenv("JWT_SECRET")
 	if secret == "" {
-		return nil, fmt.Errorf("JWT_SECRET not set")
+		return nil
 	}
-	return []byte(secret), nil
+	return []byte(secret)
+}
+
+func getPublicKey() *rsa.PublicKey {
+	pem := os.Getenv("JWT_PUBLIC_KEY")
+	if pem == "" {
+		return nil
+	}
+	rsaPub, err := jwt.ParseRSAPublicKeyFromPEM([]byte(pem))
+	if err != nil {
+		panic(err)
+	}
+	return rsaPub
 }
 
 // handleUnauthorized checks, which action should be performed if access was denied.

--- a/jwt.go
+++ b/jwt.go
@@ -11,7 +11,6 @@ import (
 	"bytes"
 
 	"github.com/dgrijalva/jwt-go"
-	"github.com/jeremywohl/flatten"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
@@ -40,7 +39,7 @@ func (h JWTAuth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) 
 		if err != nil {
 			return handleUnauthorized(w, r, p), nil
 		}
-		vClaims, err := flatten.Flatten(vToken.Claims.(jwt.MapClaims), "", flatten.DotStyle)
+		vClaims, err := Flatten(vToken.Claims.(jwt.MapClaims), "", DotStyle)
 		if err != nil {
 			return handleUnauthorized(w, r, p), nil
 		}

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -54,18 +54,16 @@ var _ = Describe("JWTAuth", func() {
 			if err := os.Setenv("JWT_SECRET", "secret"); err != nil {
 				Fail("Unexpected error setting JWT_SECRET")
 			}
-			secret, err := lookupSecret()
+			secret := lookupSecret()
 			Expect(secret).To(Equal([]byte("secret")))
-			Expect(err).To(BeNil())
 		})
 
 		It("should return an error JWT_SECRET not set", func() {
 			if err := os.Setenv("JWT_SECRET", ""); err != nil {
 				Fail("Unexpected error setting JWT_SECRET")
 			}
-			secret, err := lookupSecret()
+			secret := lookupSecret()
 			Expect(secret).To(BeNil())
-			Expect(err).To(HaveOccurred())
 		})
 	})
 

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -94,6 +94,29 @@ var _ = Describe("JWTAuth", func() {
 		})
 	})
 
+	Describe("Validate flatten map function", func() {
+
+		listMap := map[string]interface{}{"context": map[string]interface{}{"user": map[string]interface{}{"roles": []string{"admin", "user"}}}}
+		myMap := map[string]interface{}{"context": map[string]interface{}{"user": map[string]interface{}{"username": "foobar"}}}
+
+		It("Should flatten map with dots", func() {
+			result, err := Flatten(myMap, "", DotStyle)
+			if err != nil {
+				panic(err)
+			}
+			expectedMap := map[string]interface{}{"context.user.username": "foobar"}
+			Expect(result).To(Equal(expectedMap))
+		})
+		It("Should flatten map and leave slices as is", func() {
+			result, err := Flatten(listMap, "", DotStyle)
+			if err != nil {
+				panic(err)
+			}
+			expectedMap := map[string]interface{}{"context.user.roles": []string{"admin", "user"}}
+			Expect(result).To(Equal(expectedMap))
+		})
+	})
+
 	Describe("Find tokens in the request", func() {
 
 		It("should return the token if set in the Auhorization header", func() {
@@ -536,7 +559,6 @@ var _ = Describe("JWTAuth", func() {
 				Expect(result).To(Equal(http.StatusUnauthorized))
 			})
 		})
-
 	})
 
 })


### PR DESCRIPTION
Hi,
I would like to contribute RSA support.

The PR also include flattening of the claim map. This helps where you have "complex" payloads like maps in maps. you may then reference from to the field with dots.

example jwt payload:
```json
"context": {
  "user": { 
    "username": "foobar", 
    "role": ["admin", "baz"] 
   }
}
```
Would become in Caddyfile:
```hcl
jwt {
  path /foo
  allow context.user.username foobar
  allow context.role.0 admin
}
```

Please review.
tests are in the making.