### PR TITLE
add passthrough option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Token-Claim-Data.Payload: something
 
 Token claims will always be converted to a string.  If you expect your claim to be another type, remember to convert it back before you use it.  Nested JSON objects will be flattened.  In the example above, you can see that the nested `payload` field is flattened to `data.payload`.
 
+All request headers with the prefix `Token-Claim-` are stripped from the request before being forwarded upstream, so users can't spoof them.
+
 ### Allowing Public Access to Certain Paths
 
 In some cases, you may want to allow public access to a particular path without a valid token.  For example, you may want to protect all your routes except access to the `/login` path.  You can do that with the `except` directive.
@@ -133,6 +135,19 @@ jwt {
 ```
 
 Requests to `https://example.com/login` and `https://example.com/` will both be allowed without a valid token.  Any other path will require a valid token.
+
+### Allowing Public Access Regardless of Token
+
+In some cases, a page should be accessible whether a valid token is present or not. An example might be the Github home page or a public repository, which should be visible even to logged-out users. In those cases, you would want to parse any valid token that might be present and pass the claims through to the application, leaving it to the application to decide whether the user has access. You can use the directive `passthrough` for this:
+
+```
+jwt {
+  path /
+  passthrough
+}
+```
+
+It should be noted that `passthrough` will *always* allow access on the path provided, regardless of whether a token is present or valid, and regardless of `allow`/`deny` directives. The application would be responsible for acting on the parsed claims.
 
 ### Specifying Keys for Use in Validating Tokens
 

--- a/config.go
+++ b/config.go
@@ -45,6 +45,7 @@ type Rule struct {
 	AllowRoot     bool
 	KeyFile       string
 	KeyFileType   EncryptionType
+	Passthrough   bool
 }
 
 // AccessRule represents a single ALLOW/DENY rule based on the value of a claim in
@@ -163,6 +164,8 @@ func parse(c *caddy.Controller) ([]Rule, error) {
 					}
 					r.KeyFile = args1[0]
 					r.KeyFileType = HMAC
+				case "passthrough":
+					r.Passthrough = true
 				}
 			}
 			rules = append(rules, r)

--- a/config_test.go
+++ b/config_test.go
@@ -99,6 +99,15 @@ var _ = Describe("JWTAuth Config", func() {
 					publickey /test/test.pem
 					secret /test/test.secret
 				}`, true, nil},
+				{`jwt {
+					path /
+					passthrough
+				}`, false, []Rule{
+					Rule{
+						Path:        "/",
+						Passthrough: true,
+					},
+				}},
 			}
 			for _, test := range tests {
 				c := caddy.NewTestController("http", test.input)

--- a/jwt.go
+++ b/jwt.go
@@ -59,6 +59,9 @@ func (h Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		// Path matches, look for unvalidated token
 		uToken, err := ExtractToken(r)
 		if err != nil {
+			if p.Passthrough {
+				return h.Next.ServeHTTP(w, r)
+			}
 			return handleUnauthorized(w, r, p, h.Realm), nil
 		}
 

--- a/jwt.go
+++ b/jwt.go
@@ -41,6 +41,13 @@ func (h Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 			continue
 		}
 
+		// strip potentially spoofed claims
+		for header, _ := range r.Header {
+			if strings.HasPrefix(header, "Token-Claim-") {
+				r.Header.Del(header)
+			}
+		}
+
 		// Check excepted paths for this rule and allow access without validating any token
 		var isExceptedPath bool
 		for _, e := range p.ExceptedPaths {

--- a/jwt.go
+++ b/jwt.go
@@ -60,7 +60,7 @@ func (h Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		uToken, err := ExtractToken(r)
 		if err != nil {
 			if p.Passthrough {
-				return h.Next.ServeHTTP(w, r)
+				continue
 			}
 			return handleUnauthorized(w, r, p, h.Realm), nil
 		}

--- a/jwt.go
+++ b/jwt.go
@@ -87,6 +87,9 @@ func (h Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 		// Validate token
 		vToken, err := ValidateToken(uToken, b)
 		if err != nil {
+			if p.Passthrough {
+				continue
+			}
 			return handleUnauthorized(w, r, p, h.Realm), nil
 		}
 		vClaims, err := Flatten(vToken.Claims.(jwt.MapClaims), "", DotStyle)


### PR DESCRIPTION
Some applications need to let the user access paths regardless of JWT presence, but still decode and forward JWT claims upstream if a JWT is found.  This is helpful for public-facing applications with user logins, e.g. GitHub, Reddit, etc.

If `passthrough` is specified in a JWT block then instead of returning a 401, 403, or 303 for no JWT, the request will proceed as normal.