### PR TITLE
add passthru for OPTIONS requests to a matched path

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -39,6 +39,10 @@ func (h Auth) ServeHTTP(w http.ResponseWriter, r *http.Request) (int, error) {
 			continue
 		}
 
+                if r.Method == "OPTIONS" {
+                        continue
+                }
+
 		// strip potentially spoofed claims
 		for header, _ := range r.Header {
 			if strings.HasPrefix(header, "Token-Claim-") {

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -482,6 +482,18 @@ var _ = Describe("Auth", func() {
 			Expect(result).To(Equal(http.StatusOK))
 		})
 
+                It("allow OPTIONS requests to continue to next handler", func() {
+			req, err := http.NewRequest("OPTIONS", "/testing", nil)
+
+			rec := httptest.NewRecorder()
+			result, err := rw.ServeHTTP(rec, req)
+			if err != nil {
+				Fail(fmt.Sprintf("unexpected error constructing server: %s", err))
+			}
+
+			Expect(result).To(Equal(http.StatusOK))
+		})
+
 		It("allow unprotected requests to continue to next handler", func() {
 			req, err := http.NewRequest("GET", "/unprotected", nil)
 


### PR DESCRIPTION
The [specification for cors](https://www.w3.org/TR/cors/#preflight-request) preflight requests states that credentials should not be sent with `OPTIONS` requests. This PR allows for `OPTIONS` requests to pass through.

Any questions or comments regarding this PR, please let me know. Thanks :)