### PR TITLE
Added two params to control tokens in headers

### DIFF
--- a/config.go
+++ b/config.go
@@ -37,14 +37,16 @@ type Auth struct {
 
 // Rule represents the configuration for a site
 type Rule struct {
-	Path          string
-	ExceptedPaths []string
-	AccessRules   []AccessRule
-	Redirect      string
-	AllowRoot     bool
-	KeyBackends   []KeyBackend
-	Passthrough   bool
-	StripHeader   bool
+	Path                   string
+	ExceptedPaths          []string
+	AccessRules            []AccessRule
+	Redirect               string
+	AllowRoot              bool
+	KeyBackends            []KeyBackend
+	Passthrough            bool
+	StripHeader            bool
+	IndividualClaimHeaders bool
+	SingleClaimHeader      bool
 }
 
 // AccessRule represents a single ALLOW/DENY rule based on the value of a claim in
@@ -180,6 +182,10 @@ func parse(c *caddy.Controller) ([]Rule, error) {
 					r.Passthrough = true
 				case "strip_header":
 					r.StripHeader = true
+				case "individual_claim_headers":
+					r.IndividualClaimHeaders = true
+				case "single_claim_header":
+					r.SingleClaimHeader = true
 				}
 			}
 			rules = append(rules, r)

--- a/config_test.go
+++ b/config_test.go
@@ -133,6 +133,17 @@ var _ = Describe("JWTAuth Config", func() {
 						Passthrough: true,
 					},
 				}},
+				{`jwt {
+					path /
+					individual_claim_headers
+					single_claim_header
+				}`, false, []Rule{
+					Rule{
+						Path: "/",
+						IndividualClaimHeaders: true,
+						SingleClaimHeader:      true,
+					},
+				}},
 			}
 			for _, test := range tests {
 				c := caddy.NewTestController("http", test.input)

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -566,7 +566,7 @@ var _ = Describe("Auth", func() {
 		rw := Auth{
 			Next: httpserver.HandlerFunc(passThruHandler),
 			Rules: []Rule{
-				Rule{Path: "/testing", ExceptedPaths: []string{"/testing/excepted"}, KeyBackends: []KeyBackend{backend}},
+				Rule{Path: "/testing", ExceptedPaths: []string{"/testing/excepted"}, IndividualClaimHeaders: true, KeyBackends: []KeyBackend{backend}},
 			},
 			Realm: "testing.com",
 		}
@@ -728,7 +728,7 @@ var _ = Describe("Auth", func() {
 			rw := Auth{
 				Next: httpserver.HandlerFunc(passThruHandler),
 				Rules: []Rule{
-					Rule{Path: "/testing", ExceptedPaths: []string{"/testing/excepted"}, StripHeader: true, KeyBackends: []KeyBackend{backend}},
+					Rule{Path: "/testing", ExceptedPaths: []string{"/testing/excepted"}, IndividualClaimHeaders: true, StripHeader: true, KeyBackends: []KeyBackend{backend}},
 				},
 				Realm: "testing.com",
 			}


### PR DESCRIPTION
individual_claim_headers: enables the legacy individual claims in headers.
single_claim_header: enables a new header "Token-Claims" as described in [issue 19](https://github.com/BTBurke/caddy-jwt/issues/29).

Doesn't offer much in the way of refactoring, but serves the purpose.