### PR TITLE
Extract and consider all valid tokens found in the request

### DIFF
--- a/jwt_test.go
+++ b/jwt_test.go
@@ -293,25 +293,31 @@ var _ = Describe("Auth", func() {
 		It("should return the token if set in the Auhorization header", func() {
 			req, _ := http.NewRequest("GET", "/testing", nil)
 			req.Header.Set("Authorization", strings.Join([]string{"Bearer", validToken}, " "))
-			token, err := ExtractToken(req)
-			Expect(err).To(BeNil())
+			token := ExtractTokens(req)[0]
 			Expect(token).To(Equal(validToken))
 		})
 
 		It("should return the token if set in a cookie", func() {
 			req, _ := http.NewRequest("GET", "/testing", nil)
 			req.AddCookie(&http.Cookie{Name: "jwt_token", Value: validToken})
-			token, err := ExtractToken(req)
-			Expect(err).To(BeNil())
+			token := ExtractTokens(req)[0]
 			Expect(token).To(Equal(validToken))
 		})
 
 		It("should return the token if set as query parameter", func() {
 			url := strings.Join([]string{"/testing?token=", validToken}, "")
 			req, _ := http.NewRequest("GET", url, nil)
-			token, err := ExtractToken(req)
-			Expect(err).To(BeNil())
+			token := ExtractTokens(req)[0]
 			Expect(token).To(Equal(validToken))
+		})
+
+		It("should return all valid token within the request", func() {
+			url := strings.Join([]string{"/testing?token=", validToken}, "")
+			req, _ := http.NewRequest("GET", url, nil)
+			req.Header.Set("Authorization", strings.Join([]string{"Bearer", validToken}, " "))
+			req.AddCookie(&http.Cookie{Name: "jwt_token", Value: validToken})
+			tokens := ExtractTokens(req)
+			Expect(tokens).To(Equal([]string{validToken, validToken, validToken}))
 		})
 
 	})


### PR DESCRIPTION
Multiple tokens will be considered regardless of the method of delivery, if ANY token is valid, then validation is considered as passing and that token is used.

Previously, if multiple tokens were passed simultaneously (i.e. `Authorization: Bearer token1` and also `Cookie: jwt_token=token2`) then only one token would be considered for validation (i.e. `token1`). If this token was invalid then other tokens which might be valid would be ignored.

This is relevant to a scenario where caddy is being used as a reverse proxy for multiple services behind an authentication wall (i.e. an intranet) using the `jwt_token` cookie, while backend apps might be using the Authentication header for their own JWT tokens. This would effectively "shadow" the cookie, effectively blocking access.

----
This is my first time writing any Go so sorry if I butchered anything too badly, I'm also not a frequent open source contributor so sorry if I'm not violating any rules of etiquette (and please do let me know).