### PR TITLE
Filter out Cognito Prefixes

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -249,12 +249,18 @@ func contains(list interface{}, value string) bool {
 }
 
 func modTitleCase(s string) string {
+	result := ""
+
 	switch {
 	case len(s) == 0:
 		return s
 	case len(s) == 1:
-		return strings.ToUpper(s)
+		result = strings.ToUpper(s)
 	default:
-		return strings.ToUpper(string(s[0])) + s[1:]
+		result = strings.ToUpper(string(s[0])) + s[1:]
 	}
+
+	result = strings.Replace(result, "Cognito:", "Cognito_", -1)
+
+	return result
 }


### PR DESCRIPTION
First of all: YUGE THANKS for this plugin

AWS Cognito creates a weird 'Cognito:username' prefix, which makes my life upstream (proxy) a burden. e.g. after adding a fmt.Println for headername on jwt.go @ line 135:
```
headerName: Token-Claim-Iat
headerName: Token-Claim-At_hash
headerName: Token-Claim-Sub
headerName: Token-Claim-Email_verified
headerName: Token-Claim-Email
headerName: Token-Claim-Aud
headerName: Token-Claim-Iss
headerName: Token-Claim-Cognito:username
headerName: Token-Claim-Token_use
headerName: Token-Claim-Exp
headerName: Token-Claim-Event_id
headerName: Token-Claim-Auth_time
```

Later, that happens with proxy:

```
29/Jun/2018:02:37:30 -0500 [ERROR 502 /api/v1/user] net/http: invalid header field name "Token-Claim-Cognito:username"
```

This PR replaces 'Cognito:' with 'Cognito_', so we can still capture it.
