### PR TITLE
Adding the support for the configurable token sources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,25 @@ If the optional `redirect` is set, the middleware will send a redirect to the su
 
 ### Ways of passing a token for validation
 
-There are three ways to pass the token for validation: (1) in the `Authorization` header, (2) as a cookie, and (3) as a URL query parameter.  The middleware will look in those places in the order listed and return `401` if it can't find any token.
+There are three ways to pass the token for validation: (1) in the `Authorization` header, (2) as a cookie, and (3) as a URL query parameter.  The middleware will **by defaul** look in those places in the order listed and return `401` if it can't find any token.
 
 | Method               | Format                          |
 | -------------------- | ------------------------------- |
 | Authorization Header | `Authorization: Bearer <token>` |
 | Cookie               | `"jwt_token": <token>`          |
 | URL Query Parameter  | `/protected?token=<token>`      |
+
+It is possible to customize what token sources should be used via the `token_source` rule. If at one or more `token_source` rules are specified, they will be used instead of the default in the given order. For example, to
+do the same validation as default, but with the different cookie and query param  names, the user could use the following snippet:
+
+```
+jwt {
+   ...
+   token_source header
+   token_source cookie my_cookie_name
+   token_source query_param my_param_name
+}
+```
 
 ### Constructing a valid token
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If the optional `redirect` is set, the middleware will send a redirect to the su
 
 ### Ways of passing a token for validation
 
-There are three ways to pass the token for validation: (1) in the `Authorization` header, (2) as a cookie, and (3) as a URL query parameter.  The middleware will **by defaul** look in those places in the order listed and return `401` if it can't find any token.
+There are three ways to pass the token for validation: (1) in the `Authorization` header, (2) as a cookie, and (3) as a URL query parameter.  The middleware will **by default** look in those places in the order listed and return `401` if it can't find any token.
 
 | Method               | Format                          |
 | -------------------- | ------------------------------- |

--- a/config_test.go
+++ b/config_test.go
@@ -133,6 +133,50 @@ var _ = Describe("JWTAuth Config", func() {
 						Passthrough: true,
 					},
 				}},
+				{`jwt {
+					path /
+					token_source
+				}`, true, nil,
+				},
+				{`jwt {
+					path /
+					token_source unexpected
+				}`, true, nil,
+				},
+				{`jwt {
+					path /
+					token_source header foo
+				}`, true, nil,
+				},
+				{`jwt {
+					path /
+					token_source query_param
+				}`, true, nil,
+				},
+				{`jwt {
+					path /
+					token_source cookie
+				}`, true, nil,
+				},
+				{`jwt {
+					path /
+					token_source query_param param_name
+					token_source cookie cookie_name
+					token_source header
+				}`, false, []Rule{
+					Rule{
+						Path: "/",
+						TokenSources: []TokenSource{
+							&QueryTokenSource{
+								ParamName: "param_name",
+							},
+							&CookieTokenSource{
+								CookieName: "cookie_name",
+							},
+							&HeaderTokenSource{},
+						},
+					},
+				}},
 			}
 			for _, test := range tests {
 				c := caddy.NewTestController("http", test.input)
@@ -150,6 +194,7 @@ var _ = Describe("JWTAuth Config", func() {
 					Expect(rule.ExceptedPaths).To(Equal(actualRule.ExceptedPaths))
 					Expect(rule.AllowRoot).To(Equal(actualRule.AllowRoot))
 					Expect(rule.KeyBackends).To(Equal(actualRule.KeyBackends), fmt.Sprintf("expected: %v\nactual: %v", rule, actualRule))
+					Expect(rule.TokenSources).To(Equal(actualRule.TokenSources), fmt.Sprintf("expected: %v\nactual: %v", rule, actualRule))
 				}
 
 			}


### PR DESCRIPTION
This includes the actual list of checks and customisations such as cookie or query param names. Fixes #38.