### PR TITLE
Update for caddy repo move

### DIFF
--- a/config.go
+++ b/config.go
@@ -3,8 +3,8 @@ package jwt
 import (
 	"fmt"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 )
 
 // RuleType distinguishes between ALLOW and DENY rules

--- a/config_test.go
+++ b/config_test.go
@@ -7,8 +7,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/mholt/caddy"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )

--- a/jwt.go
+++ b/jwt.go
@@ -9,8 +9,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
 )
 
 type TokenSource interface {
@@ -20,7 +20,7 @@ type TokenSource interface {
 }
 
 // Extracts a token from the Authorization header in the form `Bearer <JWT Token>`
-type HeaderTokenSource struct{
+type HeaderTokenSource struct {
 	HeaderName string
 }
 

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -12,7 +12,7 @@ import (
 	"io/ioutil"
 
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/mholt/caddy/caddyhttp/httpserver"
+	"github.com/caddyserver/caddy/caddyhttp/httpserver"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )


### PR DESCRIPTION
Fixes #51 

Caddy has moved from `github.com/mholt/caddy` to `github.com/caddyserver/caddy`, and so some modules no longer build properly as of Caddy v1.0.1

This updates `caddy-jwt` so it'll work!

I saw @mholt file a few issues in other module repos, but I guess he missed this one 😉 - see also the note in https://github.com/caddyserver/caddy/releases/tag/v1.0.1

Signed-off-by: Dave Henderson <dhenderson@gmail.com>